### PR TITLE
Fixed getReportDocument Url in reports-api-use-case-guide

### DIFF
--- a/guides/use-case-guides/reports-api-use-case-guide-2020-09-04.md
+++ b/guides/use-case-guides/reports-api-use-case-guide-2020-09-04.md
@@ -361,7 +361,7 @@ Path parameter:
 #### Request example:
 
 ```
-GET https://sellingpartnerapi-na.amazon.com/reports/2020-09-04/reports/2020-09-04/documents/DOC-b8b0-4226-b4b9-0ee058ea5760
+GET https://sellingpartnerapi-na.amazon.com/reports/2020-09-04/documents/DOC-b8b0-4226-b4b9-0ee058ea5760
 ```
 
 **Response**


### PR DESCRIPTION
Fixed the Typo in getReportDocument url in the reports-api-use-case guide

*Issue #62:*

*Description of changes:* Corrected the typo in Reports-API-use-case guide documentation.
Changed the GetReportDocument API URL.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
