### PR TITLE
Deployed Documentation for the Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 ## Selling Partner API Documentation
+
+Check out the deployed API documentation.
+
+
 This repository contains documentation for developers to use to call Selling Partner APIs. You can find the API models in and currently available client helper code in the [selling-partner-api-models](https://github.com/amzn/selling-partner-api-models) repo.
 
 The [selling-partner-api-models/models](https://github.com/amzn/selling-partner-api-models/tree/main/models) directory contains all of the currently available Selling Partner API models.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
 ## Selling Partner API Documentation
 
-Check out the deployed API documentation.
-
-
-This repository contains documentation for developers to use to call Selling Partner APIs. You can find the API models in and currently available client helper code in the [selling-partner-api-models](https://github.com/amzn/selling-partner-api-models) repo.
+This repository contains [documentation](https://docs.contour.so/amzn/selling-partner-api-docs/) for developers to use to call Selling Partner APIs. You can find the API models in and currently available client helper code in the [selling-partner-api-models](https://github.com/amzn/selling-partner-api-models) repo.
 
 The [selling-partner-api-models/models](https://github.com/amzn/selling-partner-api-models/tree/main/models) directory contains all of the currently available Selling Partner API models.
 
 The [selling-partner-api-models/clients](https://github.com/amzn/selling-partner-api-models/tree/main/clients) directory contains a [Java library](https://github.com/amzn/selling-partner-api-models/tree/main/clients/sellingpartner-api-aa-java) and a [C# library](https://github.com/amzn/selling-partner-api-models/tree/main/clients/sellingpartner-api-aa-csharp) with mustache templates for use with [swagger-codegen](https://swagger.io/tools/swagger-codegen/) to generate client libraries with authentication and authorization functionality included. The templates are located in *resources/swagger-codegen*.
 
-Please see the [Selling Partner API Developer Guide](https://github.com/amzn/selling-partner-api-docs/blob/main/guides/developer-guide/SellingPartnerApiDeveloperGuide.md) for instructions to get started.
+Please see the [Selling Partner API Developer Guide](https://docs.contour.so/amzn/selling-partner-api-docs/manual-1eu2gou706yo000000000) for instructions to get started.
 
 The [guides](https://github.com/amzn/selling-partner-api-docs/tree/main/guides) directory contains various API user guides such as the [developer guide](https://github.com/amzn/selling-partner-api-docs/tree/main/guides/developer-guide).
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Hi there, ✨

There was some issue with the documentation being hard to follow referring to #180. I thought a temporary fix might help for the time being. 

Here's the [deployed documentation](https://docs.contour.so/amzn/selling-partner-api-docs)

@ganeshkrishnan1 Maybe you might find this somewhat useful? I haven't been able to update all the links but you should be able to edit and reorder things around.

If there's more enthusiasm around this, I (or someone else) could migrate the references documentation in the repository as well.

The docs are deployed on a web app I made while on break from school; it has many bugs for the time being, but if you request changes, I'll make them ASAP (at latest day of) 😄.

