### PR TITLE
Fix typo in 'Request a Login with Amazon access token' section

### DIFF
--- a/guides/en-US/developer-guide/SellingPartnerApiDeveloperGuide.md
+++ b/guides/en-US/developer-guide/SellingPartnerApiDeveloperGuide.md
@@ -1511,7 +1511,7 @@ A successful response includes the following values.
 | **access_token**  | The LWA access token. Maximum size: 2048 bytes.   |
 | **token_type**    | The type of token returned. Must be *bearer*. |
 | **expires_in**    | The number of seconds before the LWA access token becomes invalid.  |
-| **refresh_token** | The LWA access token that you submitted in the request. Maximum size: 2048 bytes. |
+| **refresh_token** | The LWA refresh token that you submitted in the request. Maximum size: 2048 bytes. |
 ```http
 HTTP/l.l 200 OK
 Content-Type: application/json;charset UTF-8


### PR DESCRIPTION
The updated value should refer to the `refresh token` instead of `access token`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
