### PR TITLE
The marketplaceIds parameter must contain one value.

### DIFF
--- a/references/product-type-definitions-api/definitionsProductTypes_2020-09-01.md
+++ b/references/product-type-definitions-api/definitionsProductTypes_2020-09-01.md
@@ -62,7 +62,7 @@ The x-amzn-RateLimit-Limit response header returns the usage plan rate limits th
 |Type|Name|Description|Schema|
 |---|---|---|---|
 |**Query**|**keywords**  <br>*optional*|A comma-delimited list of keywords to search product types by.|< string > array(csv)|
-|**Query**|**marketplaceIds**  <br>*required*|A comma-delimited list of Amazon marketplace identifiers for the request.|< string > array(csv)|
+|**Query**|**marketplaceIds**  <br>*required*|A comma-delimited list of Amazon marketplace identifiers for the request.|string|
 
 
 #### Responses


### PR DESCRIPTION
The marketplaceIds value only takes one value. So it should be string instead of list<string>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
