### PR TITLE
Fixes Incorrect and broken link in reports-api-use-case-2021-06-30

### DIFF
--- a/guides/en-US/use-case-guides/reports-api-use-case-guide/reports-api-use-case-guide_2021-06-30.md
+++ b/guides/en-US/use-case-guides/reports-api-use-case-guide/reports-api-use-case-guide_2021-06-30.md
@@ -32,7 +32,7 @@ API Version: 2021-06-30
 
   - [Step 1. Get information required to retrieve the report](#step-1-get-information-required-to-retrieve-the-report)
 
-  - [Step 2. Download and decrypt the report](#step-2-download-and-decrypt-the-report)
+  - [Step 2. Download the report](#step-2-download-the-report)
 
   - [Sample Code (Java)](#sample-code-java)
 


### PR DESCRIPTION
Changed "Download and decrypt the report" to "Download the report" and fixed the link in Contents

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
