### PR TITLE
Fixes links to use-case guide

### DIFF
--- a/references/tokens-api/tokens_2021-03-01.md
+++ b/references/tokens-api/tokens_2021-03-01.md
@@ -5,7 +5,7 @@
 ## Overview
 The Selling Partner API for Tokens provides a secure way to access a customer's PII (Personally Identifiable Information). You can call the Tokens API to get a Restricted Data Token (RDT) for one or more restricted resources that you specify. The RDT authorizes subsequent calls to restricted operations that correspond to the restricted resources that you specified.
 
-For more information, see the [Tokens API Use Case Guide](https://github.com/amzn/selling-partner-api-docs/blob/main/references/tokens-api/tokens_2021-03-01.md).
+For more information, see the [Tokens API Use Case Guide](https://github.com/amzn/selling-partner-api-docs/blob/main/guides/en-US/use-case-guides/tokens-api-use-case-guide/tokens-API-use-case-guide-2021-03-01.md).
 
 
 ### Version information
@@ -115,7 +115,7 @@ Model of a restricted resource.
 |---|---|---|
 |**method**  <br>*required*|The HTTP method in the restricted resource.|enum ([Method](#method))|
 |**path**  <br>*required*|The path in the restricted resource. Here are some path examples:<br>- ```/orders/v0/orders```. For getting an RDT for the getOrders operation of the Orders API. For bulk orders.<br>- ```/orders/v0/orders/123-1234567-1234567```. For getting an RDT for the getOrder operation of the Orders API. For a specific order.<br>- ```/orders/v0/orders/123-1234567-1234567/orderItems```. For getting an RDT for the getOrderItems operation of the Orders API. For the order items in a specific order.<br>- ```/mfn/v0/shipments/FBA1234ABC5D```. For getting an RDT for the getShipment operation of the Shipping API. For a specific shipment.<br>- ```/mfn/v0/shipments/{shipmentId}```. For getting an RDT for the getShipment operation of the Shipping API. For any of a selling partner's shipments that you specify when you call the getShipment operation.|string|
-|**dataElements**  <br>*optional*|Indicates the type of Personally Identifiable Information requested. This parameter is required only when getting an RDT for use with the getOrder, getOrders, or getOrderItems operation of the Orders API. For more information, see the [Tokens API Use Case Guide](https://github.com/amzn/selling-partner-api-docs/blob/main/references/tokens-api/tokens_2021-03-01.md). Possible values include:<br>- **buyerInfo**. On the order level this includes general identifying information about the buyer and tax-related information. On the order item level this includes gift wrap information and custom order information, if available.<br>- **shippingAddress**. This includes information for fulfilling orders.|< string > array|
+|**dataElements**  <br>*optional*|Indicates the type of Personally Identifiable Information requested. This parameter is required only when getting an RDT for use with the getOrder, getOrders, or getOrderItems operation of the Orders API. For more information, see the [Tokens API Use Case Guide](https://github.com/amzn/selling-partner-api-docs/blob/main/guides/en-US/use-case-guides/tokens-api-use-case-guide/tokens-API-use-case-guide-2021-03-01.md). Possible values include:<br>- **buyerInfo**. On the order level this includes general identifying information about the buyer and tax-related information. On the order item level this includes gift wrap information and custom order information, if available.<br>- **shippingAddress**. This includes information for fulfilling orders.|< string > array|
 
 
 <a name="createrestricteddatatokenresponse"></a>


### PR DESCRIPTION
The links were originally pointing back to this file, but it seems like they're intended to point to the [Tokens API Use Case Guide](https://github.com/amzn/selling-partner-api-docs/blob/main/guides/en-US/use-case-guides/tokens-api-use-case-guide/tokens-API-use-case-guide-2021-03-01.md).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
