### PR TITLE
Update merchantFulfillmentV0.md

### DIFF
--- a/references/merchant-fulfillment-api/merchantFulfillmentV0.md
+++ b/references/merchant-fulfillment-api/merchantFulfillmentV0.md
@@ -548,7 +548,7 @@ The postal address information.
 |**DistrictOrCounty**  <br>*optional*|The district or county.|[DistrictOrCounty](#districtorcounty)|
 |**Email**  <br>*required*|The email address.|[EmailAddress](#emailaddress)|
 |**City**  <br>*required*|The city.|[City](#city)|
-|**StateOrProvinceCode**  <br>*optional*|The state or province code.|[StateOrProvinceCode](#stateorprovincecode)|
+|**StateOrProvinceCode**  <br>*required*|The state or province code.|[StateOrProvinceCode](#stateorprovincecode)|
 |**PostalCode**  <br>*required*|The zip code or postal code.|[PostalCode](#postalcode)|
 |**CountryCode**  <br>*required*|The country code. A two-character country code, in ISO 3166-1 alpha-2 format.|[CountryCode](#countrycode)|
 |**Phone**  <br>*required*|The phone number.|[PhoneNumber](#phonenumber)|


### PR DESCRIPTION
Although the documentation shows that the StateOrProvinceCode attribute is optional, according to the MWS guide (https://docs.developer.amazonservices.com/en_US/merch_fulfill/MerchFulfill_Datatypes.html#Address) this attribute is required in the Canada, US, and UK marketplaces as well as for shipments originating from China. This remains true for the new SP-API although the documentation does not properly outline this detail clearly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.